### PR TITLE
Added azure workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ sasl.login.callback.handler.class=io.conduktor.kafka.security.oauthbearer.azure.
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required scope="https://<resource>/.default";
 ```
 
+### Workload Identity Authentication
+
+Use Azure workload identity environment variables to configure token auth bearer retriever.
+More details on Azure identity [WorkloadIdentityCredential documentation](https://learn.microsoft.com/en-us/java/api/com.azure.identity.workloadidentitycredential?view=azure-java-stable)
+
+Use `io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler` as the callback handler class and provide
+the following required parameters in the `sasl.jaas.config` property :
+- `scope` : The [scope](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-default-scope) of the token
+
+The rest of the parameters are read from the environment variables.
+- `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` : for workload identity authentication
+
+
+```properties
+sasl.login.callback.handler.class=io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required scope="https://<resource>/.default";
+```
+
 ### Other authentication methods
 [Other authentication methods](https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable) are supported yet and could be added in the future.
 

--- a/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureIdentityAccessTokenRetriever.java
+++ b/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureIdentityAccessTokenRetriever.java
@@ -5,6 +5,7 @@ import com.azure.identity.ChainedTokenCredentialBuilder;
 import com.azure.identity.ClientCertificateCredential;
 import com.azure.identity.ClientCertificateCredentialBuilder;
 import com.azure.identity.EnvironmentCredentialBuilder;
+import com.azure.identity.WorkloadIdentityCredentialBuilder;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
@@ -57,9 +58,10 @@ public class AzureIdentityAccessTokenRetriever implements AccessTokenRetriever {
         try {
             // See https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate
             // See https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
-            var chainedTokenCredentialBuilder = new ChainedTokenCredentialBuilder();
-            clientCertificateCredentials.ifPresent(chainedTokenCredentialBuilder::addFirst);
+            var chainedTokenCredentialBuilder = new ChainedTokenCredentialBuilder();            
             chainedTokenCredentialBuilder.addLast(new EnvironmentCredentialBuilder().build());
+            chainedTokenCredentialBuilder.addLast(new WorkloadIdentityCredentialBuilder().build());            
+            clientCertificateCredentials.ifPresent(chainedTokenCredentialBuilder::addLast);
 
             var clientCredentials = chainedTokenCredentialBuilder.build();
             return clientCredentials.getTokenSync(new TokenRequestContext().setScopes(scopes)).getToken();


### PR DESCRIPTION
This pull request introduces support for Azure Workload Identity, updates the README with relevant information, and changes the order of credentials in `ChainedTokenCredentialBuilder` for improved reliability.

**Changes**

* **Azure Workload Identity Support:**
    * Implemented the necessary code changes to enable the application to authenticate using Azure Workload Identity.
    * This allows the application to run in Kubernetes environments with Azure AD Workload Identity enabled.
* **README Update:**
    * Updated the README file with instructions and examples on how to configure and use Azure Workload Identity.
    * Added any relevant environment variables that needs to be set.
* **ChainedTokenCredentialBuilder Order:**
    * Modified the order of credentials within the `ChainedTokenCredentialBuilder`.
    * This change prioritizes certain credential types to improve the overall reliability of the authentication process, especially in cloud environments.
    * The updated order is:
        1.  `EnvironmentCredential`
        2.  `WorkloadIdentityCredential`
        3.  `ManagedIdentityCredential`