### PR TITLE
YSH-734: port to Kafka 4 OAuth SPI; bump azure-identity to 1.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-        <kafka.version>3.7.0</kafka.version>
-        <azure-identity.version>1.12.2</azure-identity.version>
-        <jose4j.version>0.9.4</jose4j.version>
+        <kafka.version>4.2.0</kafka.version>
+        <azure-identity.version>1.18.3</azure-identity.version>
     </properties>
 
     <dependencies>
@@ -31,20 +30,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
+            <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>${jose4j.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureIdentityAccessTokenRetriever.java
+++ b/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureIdentityAccessTokenRetriever.java
@@ -3,12 +3,13 @@ package io.conduktor.kafka.security.oauthbearer.azure;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.*;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.errors.AuthenticationException;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtRetrieverException;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.login.AppConfigurationEntry;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -17,23 +18,18 @@ import java.util.Optional;
 import static io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler.*;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class AzureIdentityAccessTokenRetriever implements AccessTokenRetriever {
+public class AzureIdentityAccessTokenRetriever implements JwtRetriever {
 
     private static final Logger log = LoggerFactory.getLogger(AzureIdentityAccessTokenRetriever.class);
     public static final String SCOPE_DELIMITER = ",";
-    final List<String> scopes;
 
-    final Optional<ClientCertificateCredential> clientCertificateCredentials;
+    private List<String> scopes = List.of();
+    private Optional<ClientCertificateCredential> clientCertificateCredentials = Optional.empty();
 
-    public AzureIdentityAccessTokenRetriever(Optional<ClientCertificateCredential> clientCertificateCredentials, List<String> scopes) {
-        this.scopes = scopes;
-        this.clientCertificateCredentials = clientCertificateCredentials;
-    }
-
-
-    public static AccessTokenRetriever create(Map<String, Object> jaasConfig) {
-        JaasOptionsUtils jou = new JaasOptionsUtils(jaasConfig);
-        var clientCertificateCredentials = Optional.ofNullable(jou.validateString(CLIENT_CERTIFICATE_CONFIG, false))
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        JaasOptionsUtils jou = new JaasOptionsUtils(saslMechanism, jaasConfigEntries);
+        this.clientCertificateCredentials = Optional.ofNullable(jou.validateString(CLIENT_CERTIFICATE_CONFIG, false))
                 .map(certificatePath ->
                         new ClientCertificateCredentialBuilder()
                                 .pfxCertificate(certificatePath)
@@ -42,15 +38,13 @@ public class AzureIdentityAccessTokenRetriever implements AccessTokenRetriever {
                                 .clientCertificatePassword(Optional.ofNullable(jou.validateString(CLIENT_CERTIFICATE_PASSWORD_CONFIG, false)).orElse(""))
                                 .build()
                 );
-        var scopes = Optional.ofNullable(jou.validateString(SCOPE_CONFIG, false))
+        this.scopes = Optional.ofNullable(jou.validateString(SCOPE_CONFIG, false))
                 .map(config -> Arrays.stream(config.split(SCOPE_DELIMITER)).map(String::trim).toList())
                 .orElse(List.of());
-
-        return new AzureIdentityAccessTokenRetriever(clientCertificateCredentials, scopes);
     }
 
     @Override
-    public String retrieve() {
+    public String retrieve() throws JwtRetrieverException {
         try {
             // See https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate
             // See https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
@@ -63,7 +57,7 @@ public class AzureIdentityAccessTokenRetriever implements AccessTokenRetriever {
             return clientCredentials.getTokenSync(new TokenRequestContext().setScopes(scopes)).getToken();
         } catch (RuntimeException e) {
             log.warn("Error while generating token using Azure identity", e);
-            throw new AuthenticationException(e);
+            throw new JwtRetrieverException(e);
         }
     }
 

--- a/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureManagedIdentityCallbackHandler.java
+++ b/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureManagedIdentityCallbackHandler.java
@@ -1,34 +1,24 @@
 package io.conduktor.kafka.security.oauthbearer.azure;
 
-import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.auth.SaslExtensions;
-import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
-import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
-import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.JwtValidator;
-import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
+import org.apache.kafka.common.security.oauthbearer.ClientJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
-import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
-import org.apache.kafka.common.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
-import javax.security.sasl.SaslException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Thin back-compat wrapper: plugs the Azure token retriever and the client-side validator into
+ * Kafka's {@link OAuthBearerLoginCallbackHandler}. New setups can instead drop this handler and set
+ * {@code sasl.oauthbearer.jwt.retriever.class} to {@link AzureIdentityAccessTokenRetriever}.
+ */
 public class AzureManagedIdentityCallbackHandler implements AuthenticateCallbackHandler {
-
-    private static final Logger log = LoggerFactory.getLogger(AzureManagedIdentityCallbackHandler.class);
 
     public static final String TENANT_ID_CONFIG = "tenantId";
     public static final String CLIENT_ID_CONFIG = OAuthBearerLoginCallbackHandler.CLIENT_ID_CONFIG;
@@ -36,94 +26,29 @@ public class AzureManagedIdentityCallbackHandler implements AuthenticateCallback
     public static final String CLIENT_CERTIFICATE_PASSWORD_CONFIG = "certificatePass";
     public static final String SCOPE_CONFIG = OAuthBearerLoginCallbackHandler.SCOPE_CONFIG;
 
-    private static final String EXTENSION_PREFIX = "extension_";
-
-    private Map<String, Object> moduleOptions;
-
-    private JwtRetriever jwtRetriever;
-
-    private JwtValidator jwtValidator;
+    private final OAuthBearerLoginCallbackHandler delegate = new OAuthBearerLoginCallbackHandler();
 
     @Override
-    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
-        this.moduleOptions = JaasOptionsUtils.getOptions(saslMechanism, jaasConfigEntries);
+    public void configure(
+            Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        var configsWithAzure = new HashMap<String, Object>(configs);
+        configsWithAzure.put(
+                SaslConfigs.SASL_OAUTHBEARER_JWT_RETRIEVER_CLASS,
+                AzureIdentityAccessTokenRetriever.class.getName());
+        // login (client-side) handler: decode only. Pin ClientJwtValidator so a stray
+        // jwks.endpoint.url can't flip the default validator to broker-side JWKS verification.
+        configsWithAzure.put(
+                SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS, ClientJwtValidator.class.getName());
+        delegate.configure(configsWithAzure, saslMechanism, jaasConfigEntries);
+    }
 
-        JwtRetriever retriever = new AzureIdentityAccessTokenRetriever();
-        retriever.configure(configs, saslMechanism, jaasConfigEntries);
-        this.jwtRetriever = retriever;
-
-        // Azure only customises token retrieval; reuse Kafka's stock client-side validator
-        // (DefaultJwtValidator -> ClientJwtValidator) to parse the JWT into an OAuthBearerToken.
-        JwtValidator validator = new DefaultJwtValidator();
-        validator.configure(configs, saslMechanism, jaasConfigEntries);
-        this.jwtValidator = validator;
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        delegate.handle(callbacks);
     }
 
     @Override
     public void close() {
-        Utils.closeQuietly(jwtRetriever, "JWT retriever");
-        Utils.closeQuietly(jwtValidator, "JWT validator");
-    }
-
-    @Override
-    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
-        checkConfigured();
-        for (Callback callback : callbacks) {
-            if (callback instanceof OAuthBearerTokenCallback) {
-                handleTokenCallback((OAuthBearerTokenCallback) callback);
-            } else if (callback instanceof SaslExtensionsCallback) {
-                handleExtensionsCallback((SaslExtensionsCallback) callback);
-            } else {
-                throw new UnsupportedCallbackException(callback);
-            }
-        }
-    }
-
-    private void handleTokenCallback(OAuthBearerTokenCallback callback) {
-        String accessToken = jwtRetriever.retrieve();
-
-        try {
-            OAuthBearerToken token = jwtValidator.validate(accessToken);
-            callback.token(token);
-        } catch (JwtValidatorException e) {
-            log.warn(e.getMessage(), e);
-            callback.error("invalid_token", e.getMessage(), null);
-        }
-    }
-
-    private void handleExtensionsCallback(SaslExtensionsCallback callback) {
-        Map<String, String> extensions = new HashMap<>();
-
-        for (Map.Entry<String, Object> configEntry : this.moduleOptions.entrySet()) {
-            String key = configEntry.getKey();
-
-            if (!key.startsWith(EXTENSION_PREFIX))
-                continue;
-
-            Object valueRaw = configEntry.getValue();
-            String value;
-
-            if (valueRaw instanceof String)
-                value = (String) valueRaw;
-            else
-                value = String.valueOf(valueRaw);
-
-            extensions.put(key.substring(EXTENSION_PREFIX.length()), value);
-        }
-
-        SaslExtensions saslExtensions = new SaslExtensions(extensions);
-
-        try {
-            OAuthBearerClientInitialResponse.validateExtensions(saslExtensions);
-        } catch (SaslException e) {
-            throw new ConfigException(e.getMessage());
-        }
-
-        callback.extensions(saslExtensions);
-    }
-
-    private void checkConfigured() {
-        if (moduleOptions == null || jwtRetriever == null || jwtValidator == null)
-            throw new IllegalStateException(String.format("To use %s, first call the configure method", getClass().getSimpleName()));
+        delegate.close();
     }
 }

--- a/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureManagedIdentityCallbackHandler.java
+++ b/src/main/java/io/conduktor/kafka/security/oauthbearer/azure/AzureManagedIdentityCallbackHandler.java
@@ -1,15 +1,19 @@
 package io.conduktor.kafka.security.oauthbearer.azure;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.SaslExtensions;
 import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
+import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.*;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +23,6 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.sasl.SaslException;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -32,58 +35,39 @@ public class AzureManagedIdentityCallbackHandler implements AuthenticateCallback
     public static final String CLIENT_CERTIFICATE_CONFIG = "certificate";
     public static final String CLIENT_CERTIFICATE_PASSWORD_CONFIG = "certificatePass";
     public static final String SCOPE_CONFIG = OAuthBearerLoginCallbackHandler.SCOPE_CONFIG;
-    public static final String TENANT_ID_DOC = "The certificate to use for certificate assertion validation";
-    public static final String CLIENT_ID_DOC = OAuthBearerLoginCallbackHandler.CLIENT_ID_DOC;
-    public static final String CLIENT_CERTIFICATE_DOC = "The certificate to use for certificate assertion validation";
-    public static final String CLIENT_CERTIFICATE_PASSWORD_DOC = "The passphrase for certificate";
-    public static final String SCOPE_DOC = OAuthBearerLoginCallbackHandler.SCOPE_DOC;
 
     private static final String EXTENSION_PREFIX = "extension_";
 
     private Map<String, Object> moduleOptions;
 
-    private AccessTokenRetriever accessTokenRetriever;
+    private JwtRetriever jwtRetriever;
 
-    private AccessTokenValidator accessTokenValidator;
-
-    private boolean isInitialized = false;
-
+    private JwtValidator jwtValidator;
 
     @Override
     public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
         this.moduleOptions = JaasOptionsUtils.getOptions(saslMechanism, jaasConfigEntries);
-        AccessTokenRetriever accessTokenRetriever = AzureIdentityAccessTokenRetriever.create(this.moduleOptions);
-        AccessTokenValidator accessTokenValidator = AccessTokenValidatorFactory.create(configs, saslMechanism);
-        this.init(accessTokenRetriever, accessTokenValidator);
-    }
 
-    public void init(AccessTokenRetriever accessTokenRetriever, AccessTokenValidator accessTokenValidator) {
-        this.accessTokenRetriever = accessTokenRetriever;
-        this.accessTokenValidator = accessTokenValidator;
+        JwtRetriever retriever = new AzureIdentityAccessTokenRetriever();
+        retriever.configure(configs, saslMechanism, jaasConfigEntries);
+        this.jwtRetriever = retriever;
 
-        try {
-            this.accessTokenRetriever.init();
-        } catch (IOException var4) {
-            throw new KafkaException("The OAuth login configuration encountered an error when initializing the AccessTokenRetriever", var4);
-        }
-
-        this.isInitialized = true;
+        // Azure only customises token retrieval; reuse Kafka's stock client-side validator
+        // (DefaultJwtValidator -> ClientJwtValidator) to parse the JWT into an OAuthBearerToken.
+        JwtValidator validator = new DefaultJwtValidator();
+        validator.configure(configs, saslMechanism, jaasConfigEntries);
+        this.jwtValidator = validator;
     }
 
     @Override
     public void close() {
-        if (accessTokenRetriever != null) {
-            try {
-                this.accessTokenRetriever.close();
-            } catch (IOException e) {
-                log.warn("The OAuth login configuration encountered an error when closing the AccessTokenRetriever", e);
-            }
-        }
+        Utils.closeQuietly(jwtRetriever, "JWT retriever");
+        Utils.closeQuietly(jwtValidator, "JWT validator");
     }
 
     @Override
-    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        checkInitialized();
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        checkConfigured();
         for (Callback callback : callbacks) {
             if (callback instanceof OAuthBearerTokenCallback) {
                 handleTokenCallback((OAuthBearerTokenCallback) callback);
@@ -95,22 +79,19 @@ public class AzureManagedIdentityCallbackHandler implements AuthenticateCallback
         }
     }
 
-    private void handleTokenCallback(OAuthBearerTokenCallback callback) throws IOException {
-        checkInitialized();
-        String accessToken = accessTokenRetriever.retrieve();
+    private void handleTokenCallback(OAuthBearerTokenCallback callback) {
+        String accessToken = jwtRetriever.retrieve();
 
         try {
-            OAuthBearerToken token = accessTokenValidator.validate(accessToken);
+            OAuthBearerToken token = jwtValidator.validate(accessToken);
             callback.token(token);
-        } catch (ValidateException e) {
+        } catch (JwtValidatorException e) {
             log.warn(e.getMessage(), e);
             callback.error("invalid_token", e.getMessage(), null);
         }
     }
 
     private void handleExtensionsCallback(SaslExtensionsCallback callback) {
-        checkInitialized();
-
         Map<String, String> extensions = new HashMap<>();
 
         for (Map.Entry<String, Object> configEntry : this.moduleOptions.entrySet()) {
@@ -141,8 +122,8 @@ public class AzureManagedIdentityCallbackHandler implements AuthenticateCallback
         callback.extensions(saslExtensions);
     }
 
-    private void checkInitialized() {
-        if (!isInitialized)
-            throw new IllegalStateException(String.format("To use %s, first call the configure or init method", getClass().getSimpleName()));
+    private void checkConfigured() {
+        if (moduleOptions == null || jwtRetriever == null || jwtValidator == null)
+            throw new IllegalStateException(String.format("To use %s, first call the configure method", getClass().getSimpleName()));
     }
 }


### PR DESCRIPTION
## Summary

Gateway 3.20.0 bumps the internal Kafka client to 4.2 (YSH-711). Kafka 4 removed the
internal OAuth SPI — `oauthbearer.internals.secured.*` (`AccessTokenRetriever`,
`AccessTokenValidator`, `AccessTokenValidatorFactory`, `ValidateException`) — that this
library implemented, so the current `0.5.0` jar throws `NoClassDefFoundError` when loaded
by a 4.2 client. This ports the library to the Kafka 4 JWT SPI.

Ref: YSH-734.

## Changes

- **`AzureIdentityAccessTokenRetriever`** — now `implements JwtRetriever` (no-arg ctor +
  `configure()`; `retrieve()` throws `JwtRetrieverException`). Azure stays the token source
  via `ChainedTokenCredential`.
- **`AzureManagedIdentityCallbackHandler`** — collapsed to a thin delegator over the stock
  `OAuthBearerLoginCallbackHandler` (injects our retriever + `ClientJwtValidator`); see
  **Design** below.
- **`pom.xml`** — `kafka_2.13` → `kafka-clients`, `<kafka.version>` `3.7.0` → `4.2.0`,
  drop `jose4j` (the client-side validator no longer needs it), `azure-identity`
  `1.12.2` → `1.18.3`.

The public config interface is unchanged (`clientId` / `tenantId` / `certificate` /
`certificatePass` / `scope`) — existing deployments need no config changes.

## Design: a thin login-side delegator

`AzureManagedIdentityCallbackHandler` is a thin wrapper over Kafka 4's
`OAuthBearerLoginCallbackHandler` — it injects `AzureIdentityAccessTokenRetriever`
(`sasl.oauthbearer.jwt.retriever.class`) and pins `ClientJwtValidator`
(`sasl.oauthbearer.jwt.validator.class`), then delegates `configure`/`handle`/`close`.

**Why `ClientJwtValidator`, not `BrokerJwtValidator`:** this is a *login* (client-side)
handler — it obtains and presents a token (`OAuthBearerTokenCallback`), it never validates
incoming ones (`OAuthBearerValidatorCallback`). Its validator only *decodes* the token we
just fetched from Entra to build the `OAuthBearerToken`; the client doesn't verify its own
token's signature — the receiver does. Broker-side JWKS verification (`BrokerJwtValidator`)
belongs in the *consumer's* server-side OAuth (for the Gateway: `GATEWAY_OAUTH_JWKS_URL` /
`OAuthBearerValidatorCallbackHandler`), a separate handler — this library can't be one (it
doesn't implement `OAuthBearerValidatorCallback`).

Pinning also hardens it: with the stock default (`DefaultJwtValidator`), a stray
`sasl.oauthbearer.jwks.endpoint.url` in the client config flips it to `BrokerJwtValidator`
(needs `allowed.urls` + jose4j → broken login). `ClientJwtValidator` ignores it.

**Back-compat / alternative:** same class name, so existing
`sasl.login.callback.handler.class=…AzureManagedIdentityCallbackHandler` configs keep
working. New setups can drop the handler and set
`sasl.oauthbearer.jwt.retriever.class=…AzureIdentityAccessTokenRetriever`.

## Testing

- Builds against `kafka-clients` 4.2.0.
- conduktor-proxy `FeatureTest` loads both classes on the 4.2 classpath with the
  name-skip removed (4/4 green).

### Manual end-to-end — OAUTHBEARER → Conduktor Gateway on Kafka 4

A real **Apache Kafka 4.2** client using this library authenticated to a Conduktor Gateway
(kafka-clients 4.2) with an **Azure Entra** token:

- **Client:** `kafka-topics` (Kafka 4.2.0) + `azure-kafka-oauthbearer` + `azure-identity`
  on the classpath; `SASL_PLAINTEXT` / `OAUTHBEARER` / `AzureManagedIdentityCallbackHandler`;
  service-principal creds supplied via `AZURE_*` env (EnvironmentCredential).
- **Token:** real client-credentials token from Entra — decoded
  `iss=https://sts.windows.net/<tenant>/`, `aud=api://<clientId>`, `ver=1.0`.
- **Gateway:** OAUTHBEARER listener validating the token against the Entra JWKS + issuer.
- **Result:** `kafka-topics --list` succeeded (`exit=0`, no auth errors):

```
__consumer_offsets
_conduktor_gateway_acls
_conduktor_gateway_auditlogs
_conduktor_gateway_consumer_offsets
_conduktor_gateway_encryption_keys
_conduktor_gateway_groups
_conduktor_gateway_interceptor_configs
_conduktor_gateway_topicmappings
_conduktor_gateway_usermappings
_conduktor_gateway_vclusters
```

## Follow-ups (release-gated, separate PRs)

- [ ] Release `0.6.0`.
- [ ] conduktor-proxy: bump the dep `0.5.0` → `0.6.0` and remove the `FeatureTest` azure
      name-skip (only after `0.6.0` is published).
- [ ] (Optional) verify the certificate-assertion path against a real Event Hubs upstream.
